### PR TITLE
Demonstrate & validate method doc comments (wrapping-c-library)

### DIFF
--- a/outputs/tutorial-qml-ui-app.md
+++ b/outputs/tutorial-qml-ui-app.md
@@ -627,7 +627,15 @@ Launch basecamp pointed at that data directory. The `calc_ui` plugin appears in 
 
 ![calc_module returns 3 + 5 = 8](images/basecamp-calc-installed.png)
 
+The doc comments you wrote on `calc_module`'s methods in Part 1 also
+surface in basecamp. Open **Modules → Core Modules**, then view
+`calc_module`'s methods — each method shows its `description`.
+
+![Per-method descriptions render (single- and multi-line)](images/basecamp-method-docs.png)
+
 The result `8` comes back from `calc_module`: pressing **Add** calls `logos.callModule("calc_module", "add", [3, 5])`, which basecamp routes to your core module and back to the QML view. Both modules — the `calc_module` core plugin and the `calc_ui` view plugin — are loaded from the `basecamp-data` directory you installed them into.
+
+The **Methods** screen (Modules → Core Modules → *View Methods*) lists each method with the `description` from its doc comment — the same docs `lm` and `logoscore module-info` showed in Part 1, here in the GUI. `factorial`'s two `///` lines render as two lines, exactly as written.
 
 The sidebar labels each UI plugin by its `name` from `metadata.json`, which is why the tab reads `calc_ui`.
 

--- a/outputs/tutorial-wrapping-c-library.md
+++ b/outputs/tutorial-wrapping-c-library.md
@@ -371,10 +371,12 @@ public:
     // The generator maps C++ types onto the wire automatically:
     //   int64_t  ↔ int      std::string ↔ QString      bool ↔ bool
     //
-    // A `///` doc comment directly above a method becomes that method's
+    // A doc comment directly above a method becomes that method's
     // `description` in getMethods() — surfaced by `lm`, `logoscore
-    // module-info`, and Basecamp's Methods list. (Plain `//` comments
-    // like this block are ignored, so they never leak into the API.)
+    // module-info`, and Basecamp's Methods list. Use `///` (one or
+    // more lines) or a `/** ... */` block; a multi-line comment is
+    // joined into a single description. (Plain `//` comments like this
+    // block are ignored, so they never leak into the API.)
 
     /// Adds two integers and returns the sum.
     int64_t add(int64_t a, int64_t b);
@@ -382,13 +384,19 @@ public:
     /// Multiplies two integers and returns the product.
     int64_t multiply(int64_t a, int64_t b);
 
+    // A multi-line description: consecutive `///` lines are joined.
     /// Computes the factorial n! of a non-negative integer.
+    /// Defined as n * (n-1) * ... * 1, with 0! = 1.
     int64_t factorial(int64_t n);
 
     /// Returns the nth Fibonacci number (0-indexed).
     int64_t fibonacci(int64_t n);
 
-    /// Returns the version string of the wrapped libcalc C library.
+    // A `/** ... */` block comment works too (also joined to one line).
+    /**
+     * Returns the version string of the wrapped libcalc C library.
+     * Read straight from the linked native library, not metadata.json.
+     */
     std::string libVersion();
 
     /// Looks up the library version and emits it as a `versionReady`
@@ -601,8 +609,9 @@ Dependencies: (none)
 ./lm/bin/lm methods result/lib/calc_module_plugin.dylib
 ```
 
-Output — each method you declared, with its `///` doc comment shown on a
-`Description:` line:
+Output — each method you declared, with its doc comment shown on a
+`Description:` line. Note `factorial` (two `///` lines) and `libVersion`
+(a `/** ... */` block) are each joined into a single description:
 
 ```
 Plugin Methods:
@@ -621,7 +630,7 @@ int multiply(int a, int b)
 int factorial(int n)
   Signature: factorial(int)
   Invokable: yes
-  Description: Computes the factorial n! of a non-negative integer.
+  Description: Computes the factorial n! of a non-negative integer. Defined as n * (n-1) * ... * 1, with 0! = 1.
 
 int fibonacci(int n)
   Signature: fibonacci(int)
@@ -631,7 +640,7 @@ int fibonacci(int n)
 QString libVersion()
   Signature: libVersion()
   Invokable: yes
-  Description: Returns the version string of the wrapped libcalc C library.
+  Description: Returns the version string of the wrapped libcalc C library. Read straight from the linked native library, not metadata.json.
 
 void libVersionNotify()
   Signature: libVersionNotify()
@@ -639,10 +648,11 @@ void libVersionNotify()
   Description: Looks up the library version and emits it as a `versionReady` event instead of returning it. Used by the QML tutorial (Part 2).
 ```
 
-Two things to notice:
+Three things to notice:
 
 - **Signatures are Qt-typed** (`int`, `QString`) even though you wrote `int64_t` / `std::string`. That's the generated glue: `lm` reports the wire types the synthesized Qt plugin exposes, so `int64_t add(int64_t, int64_t)` shows up as `add(int,int)`.
-- **Each `Description:` line is your `///` doc comment**, carried through the module's `getMethods()` introspection. Plain `//` comments (like the type-mapping note in the header) are deliberately ignored, so only intentional docs surface; an undocumented method simply omits the line. The same descriptions appear in `logoscore module-info` and Basecamp's Methods list.
+- **Each `Description:` line is your doc comment**, carried through the module's `getMethods()` introspection. Plain `//` comments (like the type-mapping note in the header) are deliberately ignored, so only intentional docs surface; an undocumented method simply omits the line.
+- **Multi-line comments are joined into one line** — `factorial`'s two `///` lines and `libVersion`'s `/** ... */` block each become a single `description`. The same descriptions appear in `logoscore module-info` and Basecamp's Methods list.
 
 ### 5.4 JSON output
 
@@ -734,7 +744,7 @@ sleep 3
 
 ### 6.4 Inspect methods and their docs
 
-`module-info` lists each method with its signature and the `///` description you wrote — the same docs `lm` showed, here straight from the module's `getPluginMethods` introspection:
+`module-info` lists each method with its signature and the doc-comment description you wrote — the same docs `lm` showed, here straight from the module's `getPluginMethods` introspection:
 
 ```bash
 ./logos/bin/logoscore module-info calc_module
@@ -753,17 +763,19 @@ Methods:
   multiply(a: int, b: int) -> int
       Multiplies two integers and returns the product.
   factorial(n: int) -> int
-      Computes the factorial n! of a non-negative integer.
+      Computes the factorial n! of a non-negative integer. Defined as n * (n-1) * ... * 1, with 0! = 1.
   fibonacci(n: int) -> int
       Returns the nth Fibonacci number (0-indexed).
   libVersion() -> QString
-      Returns the version string of the wrapped libcalc C library.
+      Returns the version string of the wrapped libcalc C library. Read straight from the linked native library, not metadata.json.
   libVersionNotify() -> void
       Looks up the library version and emits it as a `versionReady` event instead of returning it. Used by the QML tutorial (Part 2).
 ```
 
-An undocumented method would still appear, just without the indented
-description line.
+The `factorial` and `libVersion` descriptions show how a multi-line doc
+comment (multiple `///` lines or a `/** ... */` block) is joined into one
+line. An undocumented method would still appear, just without the
+indented description line.
 
 ### 6.5 Call methods
 

--- a/outputs/tutorial-wrapping-c-library.md
+++ b/outputs/tutorial-wrapping-c-library.md
@@ -374,9 +374,9 @@ public:
     // A doc comment directly above a method becomes that method's
     // `description` in getMethods() — surfaced by `lm`, `logoscore
     // module-info`, and Basecamp's Methods list. Use `///` (one or
-    // more lines) or a `/** ... */` block; a multi-line comment is
-    // joined into a single description. (Plain `//` comments like this
-    // block are ignored, so they never leak into the API.)
+    // more lines) or a `/** ... */` block; the comment's line breaks
+    // are preserved. (Plain `//` comments like this block are
+    // ignored, so they never leak into the API.)
 
     /// Adds two integers and returns the sum.
     int64_t add(int64_t a, int64_t b);
@@ -384,7 +384,7 @@ public:
     /// Multiplies two integers and returns the product.
     int64_t multiply(int64_t a, int64_t b);
 
-    // A multi-line description: consecutive `///` lines are joined.
+    // A multi-line description: consecutive `///` lines keep their breaks.
     /// Computes the factorial n! of a non-negative integer.
     /// Defined as n * (n-1) * ... * 1, with 0! = 1.
     int64_t factorial(int64_t n);
@@ -392,7 +392,7 @@ public:
     /// Returns the nth Fibonacci number (0-indexed).
     int64_t fibonacci(int64_t n);
 
-    // A `/** ... */` block comment works too (also joined to one line).
+    // A `/** ... */` block comment works too (line breaks preserved).
     /**
      * Returns the version string of the wrapped libcalc C library.
      * Read straight from the linked native library, not metadata.json.
@@ -609,9 +609,10 @@ Dependencies: (none)
 ./lm/bin/lm methods result/lib/calc_module_plugin.dylib
 ```
 
-Output — each method you declared, with its doc comment shown on a
-`Description:` line. Note `factorial` (two `///` lines) and `libVersion`
-(a `/** ... */` block) are each joined into a single description:
+Output — each method you declared, with its doc comment as a
+`Description`. A single-line comment renders inline; a multi-line
+comment (`factorial`'s two `///` lines, `libVersion`'s `/** ... */`
+block, and `libVersionNotify`'s two `///` lines) keeps its line breaks:
 
 ```
 Plugin Methods:
@@ -630,7 +631,9 @@ int multiply(int a, int b)
 int factorial(int n)
   Signature: factorial(int)
   Invokable: yes
-  Description: Computes the factorial n! of a non-negative integer. Defined as n * (n-1) * ... * 1, with 0! = 1.
+  Description:
+    Computes the factorial n! of a non-negative integer.
+    Defined as n * (n-1) * ... * 1, with 0! = 1.
 
 int fibonacci(int n)
   Signature: fibonacci(int)
@@ -640,19 +643,23 @@ int fibonacci(int n)
 QString libVersion()
   Signature: libVersion()
   Invokable: yes
-  Description: Returns the version string of the wrapped libcalc C library. Read straight from the linked native library, not metadata.json.
+  Description:
+    Returns the version string of the wrapped libcalc C library.
+    Read straight from the linked native library, not metadata.json.
 
 void libVersionNotify()
   Signature: libVersionNotify()
   Invokable: yes
-  Description: Looks up the library version and emits it as a `versionReady` event instead of returning it. Used by the QML tutorial (Part 2).
+  Description:
+    Looks up the library version and emits it as a `versionReady`
+    event instead of returning it. Used by the QML tutorial (Part 2).
 ```
 
 Three things to notice:
 
 - **Signatures are Qt-typed** (`int`, `QString`) even though you wrote `int64_t` / `std::string`. That's the generated glue: `lm` reports the wire types the synthesized Qt plugin exposes, so `int64_t add(int64_t, int64_t)` shows up as `add(int,int)`.
-- **Each `Description:` line is your doc comment**, carried through the module's `getMethods()` introspection. Plain `//` comments (like the type-mapping note in the header) are deliberately ignored, so only intentional docs surface; an undocumented method simply omits the line.
-- **Multi-line comments are joined into one line** — `factorial`'s two `///` lines and `libVersion`'s `/** ... */` block each become a single `description`. The same descriptions appear in `logoscore module-info` and Basecamp's Methods list.
+- **Each `Description` is your doc comment**, carried through the module's `getMethods()` introspection. Plain `//` comments (like the type-mapping note in the header) are deliberately ignored, so only intentional docs surface; an undocumented method simply omits it.
+- **Line breaks are preserved** — a single-line comment renders inline; a multi-line comment (`factorial`, `libVersion`, `libVersionNotify`) keeps its breaks. The same descriptions appear in `logoscore module-info` and Basecamp's Methods list.
 
 ### 5.4 JSON output
 
@@ -683,8 +690,11 @@ For scripting and CI, use `--json`:
 ]
 ```
 
-The `description` field is the method's `///` doc comment. Methods
-without a doc comment omit it.
+The `description` field is the method's doc comment. A multi-line
+comment is carried verbatim with embedded `\n` (e.g. `factorial`:
+`"Computes the factorial n! of a non-negative integer.\nDefined as
+n * (n-1) * ... * 1, with 0! = 1."`). Methods without a doc comment
+omit the field.
 
 ---
 
@@ -763,19 +773,22 @@ Methods:
   multiply(a: int, b: int) -> int
       Multiplies two integers and returns the product.
   factorial(n: int) -> int
-      Computes the factorial n! of a non-negative integer. Defined as n * (n-1) * ... * 1, with 0! = 1.
+      Computes the factorial n! of a non-negative integer.
+      Defined as n * (n-1) * ... * 1, with 0! = 1.
   fibonacci(n: int) -> int
       Returns the nth Fibonacci number (0-indexed).
   libVersion() -> QString
-      Returns the version string of the wrapped libcalc C library. Read straight from the linked native library, not metadata.json.
+      Returns the version string of the wrapped libcalc C library.
+      Read straight from the linked native library, not metadata.json.
   libVersionNotify() -> void
-      Looks up the library version and emits it as a `versionReady` event instead of returning it. Used by the QML tutorial (Part 2).
+      Looks up the library version and emits it as a `versionReady`
+      event instead of returning it. Used by the QML tutorial (Part 2).
 ```
 
-The `factorial` and `libVersion` descriptions show how a multi-line doc
-comment (multiple `///` lines or a `/** ... */` block) is joined into one
-line. An undocumented method would still appear, just without the
-indented description line.
+`factorial`, `libVersion`, and `libVersionNotify` show how a multi-line
+doc comment (multiple `///` lines or a `/** ... */` block) keeps its line
+breaks. An undocumented method would still appear, just without the
+indented description.
 
 ### 6.5 Call methods
 

--- a/outputs/tutorial-wrapping-c-library.md
+++ b/outputs/tutorial-wrapping-c-library.md
@@ -370,14 +370,29 @@ public:
     // ── Public API — every method here is callable over IPC ──────────
     // The generator maps C++ types onto the wire automatically:
     //   int64_t  ↔ int      std::string ↔ QString      bool ↔ bool
+    //
+    // A `///` doc comment directly above a method becomes that method's
+    // `description` in getMethods() — surfaced by `lm`, `logoscore
+    // module-info`, and Basecamp's Methods list. (Plain `//` comments
+    // like this block are ignored, so they never leak into the API.)
+
+    /// Adds two integers and returns the sum.
     int64_t add(int64_t a, int64_t b);
+
+    /// Multiplies two integers and returns the product.
     int64_t multiply(int64_t a, int64_t b);
+
+    /// Computes the factorial n! of a non-negative integer.
     int64_t factorial(int64_t n);
+
+    /// Returns the nth Fibonacci number (0-indexed).
     int64_t fibonacci(int64_t n);
+
+    /// Returns the version string of the wrapped libcalc C library.
     std::string libVersion();
 
-    // Fire-and-forget: looks up the version, then emits it as an event
-    // instead of returning it. Used by the QML tutorial (Part 2).
+    /// Looks up the library version and emits it as a `versionReady`
+    /// event instead of returning it. Used by the QML tutorial (Part 2).
     void libVersionNotify();
 
     // ── Events ───────────────────────────────────────────────────────
@@ -409,6 +424,7 @@ logos_events:
   | `StdLogosResult`            | `LogosResult` (from `<logos_result.h>`) — `{ success, value, error }` |
 
 - Use `int64_t` for integers (not `int`) — that's the type the parser recognizes.
+- **Document methods with `///`.** A doc comment (`///` or `/** … */`) directly above a method becomes its `description` in the module's introspection, surfaced by `lm`, `logoscore module-info`, and Basecamp. Plain `//` comments are ignored, so only intentional docs are exposed — you'll see this in action in Step 5.
 - Events are declared in a `logos_events:` section. The token is recognized by the generator before preprocessing; under a normal compile it just expands to `public`.
 
 ### 3.5 `src/calc_module_impl.cpp` — Implementation
@@ -585,48 +601,48 @@ Dependencies: (none)
 ./lm/bin/lm methods result/lib/calc_module_plugin.dylib
 ```
 
-Output:
+Output — each method you declared, with its `///` doc comment shown on a
+`Description:` line:
 
 ```
 Plugin Methods:
 ===============
 
-void eventResponse(QString eventName, QVariantList args)
-  Signature: eventResponse(QString,QVariantList)
-  Invokable: no
-
-void initLogos(LogosAPI* api)
-  Signature: initLogos(LogosAPI*)
-  Invokable: yes
-
 int add(int a, int b)
   Signature: add(int,int)
   Invokable: yes
+  Description: Adds two integers and returns the sum.
 
 int multiply(int a, int b)
   Signature: multiply(int,int)
   Invokable: yes
+  Description: Multiplies two integers and returns the product.
 
 int factorial(int n)
   Signature: factorial(int)
   Invokable: yes
+  Description: Computes the factorial n! of a non-negative integer.
 
 int fibonacci(int n)
   Signature: fibonacci(int)
   Invokable: yes
+  Description: Returns the nth Fibonacci number (0-indexed).
 
 QString libVersion()
   Signature: libVersion()
   Invokable: yes
+  Description: Returns the version string of the wrapped libcalc C library.
 
 void libVersionNotify()
   Signature: libVersionNotify()
   Invokable: yes
+  Description: Looks up the library version and emits it as a `versionReady` event instead of returning it. Used by the QML tutorial (Part 2).
 ```
 
-Notice the signatures are **Qt-typed** (`int`, `QString`) even though you wrote `int64_t` / `std::string`. That's the generated glue at work: `lm` is inspecting the synthesized Qt plugin, not your impl class. Your `int64_t add(int64_t, int64_t)` shows up on the wire as `add(int,int)`.
+Two things to notice:
 
-The `eventResponse` signal and `initLogos` method are also part of the generated wrapper — you didn't write them. `initLogos` is how the host hands the module its `LogosAPI`; `eventResponse` is the channel your `versionReady` event travels over. Both come for free with `interface: universal`.
+- **Signatures are Qt-typed** (`int`, `QString`) even though you wrote `int64_t` / `std::string`. That's the generated glue: `lm` reports the wire types the synthesized Qt plugin exposes, so `int64_t add(int64_t, int64_t)` shows up as `add(int,int)`.
+- **Each `Description:` line is your `///` doc comment**, carried through the module's `getMethods()` introspection. Plain `//` comments (like the type-mapping note in the header) are deliberately ignored, so only intentional docs surface; an undocumented method simply omits the line. The same descriptions appear in `logoscore module-info` and Basecamp's Methods list.
 
 ### 5.4 JSON output
 
@@ -643,6 +659,7 @@ For scripting and CI, use `--json`:
 ```json
 [
     {
+        "description": "Adds two integers and returns the sum.",
         "isInvokable": true,
         "name": "add",
         "parameters": [
@@ -655,6 +672,9 @@ For scripting and CI, use `--json`:
     ...
 ]
 ```
+
+The `description` field is the method's `///` doc comment. Methods
+without a doc comment omit it.
 
 ---
 
@@ -696,9 +716,9 @@ modules/calc_module/
 └── variant                    # Platform variant identifier
 ```
 
-### 6.3 Call methods
+### 6.3 Start the daemon and load the module
 
-Start the daemon and call methods:
+Start the daemon and load `calc_module`:
 
 ```bash
 ./logos/bin/logoscore -D -m ./modules &
@@ -711,6 +731,43 @@ sleep 3
 ```bash
 ./logos/bin/logoscore load-module calc_module
 ```
+
+### 6.4 Inspect methods and their docs
+
+`module-info` lists each method with its signature and the `///` description you wrote — the same docs `lm` showed, here straight from the module's `getPluginMethods` introspection:
+
+```bash
+./logos/bin/logoscore module-info calc_module
+```
+
+```
+Name:          calc_module
+Version:       v1.0.0
+Status:        loaded
+PID:           48213
+Uptime:        3s
+
+Methods:
+  add(a: int, b: int) -> int
+      Adds two integers and returns the sum.
+  multiply(a: int, b: int) -> int
+      Multiplies two integers and returns the product.
+  factorial(n: int) -> int
+      Computes the factorial n! of a non-negative integer.
+  fibonacci(n: int) -> int
+      Returns the nth Fibonacci number (0-indexed).
+  libVersion() -> QString
+      Returns the version string of the wrapped libcalc C library.
+  libVersionNotify() -> void
+      Looks up the library version and emits it as a `versionReady` event instead of returning it. Used by the QML tutorial (Part 2).
+```
+
+An undocumented method would still appear, just without the indented
+description line.
+
+### 6.5 Call methods
+
+Now call them:
 
 ```bash
 ./logos/bin/logoscore call calc_module add 3 5

--- a/outputs/tutorial-wrapping-c-library.md
+++ b/outputs/tutorial-wrapping-c-library.md
@@ -372,11 +372,11 @@ public:
     //   int64_t  ↔ int      std::string ↔ QString      bool ↔ bool
     //
     // A doc comment directly above a method becomes that method's
-    // `description` in getMethods() — surfaced by `lm`, `logoscore
-    // module-info`, and Basecamp's Methods list. Use `///` (one or
-    // more lines) or a `/** ... */` block; the comment's line breaks
-    // are preserved. (Plain `//` comments like this block are
-    // ignored, so they never leak into the API.)
+    // `description` in the module's method introspection — surfaced
+    // by `lm`, `logoscore module-info`, and Basecamp's Methods list.
+    // Use `///` (one or more lines) or a `/** ... */` block; the
+    // comment's line breaks are preserved. (Plain `//` comments like
+    // this block are ignored, so they never leak into the API.)
 
     /// Adds two integers and returns the sum.
     int64_t add(int64_t a, int64_t b);
@@ -658,7 +658,7 @@ void libVersionNotify()
 Three things to notice:
 
 - **Signatures are Qt-typed** (`int`, `QString`) even though you wrote `int64_t` / `std::string`. That's the generated glue: `lm` reports the wire types the synthesized Qt plugin exposes, so `int64_t add(int64_t, int64_t)` shows up as `add(int,int)`.
-- **Each `Description` is your doc comment**, carried through the module's `getMethods()` introspection. Plain `//` comments (like the type-mapping note in the header) are deliberately ignored, so only intentional docs surface; an undocumented method simply omits it.
+- **Each `Description` is your doc comment**, carried through the module's method introspection. Plain `//` comments (like the type-mapping note in the header) are deliberately ignored, so only intentional docs surface; an undocumented method simply omits it.
 - **Line breaks are preserved** — a single-line comment renders inline; a multi-line comment (`factorial`, `libVersion`, `libVersionNotify`) keeps its breaks. The same descriptions appear in `logoscore module-info` and Basecamp's Methods list.
 
 ### 5.4 JSON output
@@ -754,7 +754,7 @@ sleep 3
 
 ### 6.4 Inspect methods and their docs
 
-`module-info` lists each method with its signature and the doc-comment description you wrote — the same docs `lm` showed, here straight from the module's `getPluginMethods` introspection:
+`module-info` lists each method with its signature and the doc-comment description you wrote — the same docs `lm` showed, here straight from the module's method introspection:
 
 ```bash
 ./logos/bin/logoscore module-info calc_module

--- a/tests/tutorial-qml-ui-app.test.yaml
+++ b/tests/tutorial-qml-ui-app.test.yaml
@@ -674,8 +674,41 @@ sections:
               texts: ["8"]
               timeout: 10000
               screenshot: "basecamp-calc-installed.png"
+            # ── Verify the `///` method docs surface on the Methods screen ──────
+            - name: "Open the Modules system view"
+              text: |
+                The doc comments you wrote on `calc_module`'s methods in Part 1 also
+                surface in basecamp. Open **Modules → Core Modules**, then view
+                `calc_module`'s methods — each method shows its `description`.
+              action: click
+              target: "Modules"
+            - name: "Switch to the Core Modules tab"
+              action: click
+              target: "Core Modules"
+            - name: "calc_module is listed"
+              action: wait_for
+              texts: ["calc_module"]
+              timeout: 15000
+            # Every module row's "View Methods" button shares the same label, so
+            # open calc_module's Methods screen by name via the view's
+            # openMethods() helper (equivalent to clicking its button).
+            - name: "Open calc_module's Methods screen"
+              action: call_method
+              find_by: "objectName"
+              find_value: "coreModulesView"
+              method: "openMethods"
+              args: ["calc_module"]
+            - name: "Per-method descriptions render (single- and multi-line)"
+              action: wait_for
+              texts:
+                - "Adds two integers and returns the sum."
+                - "Computes the factorial n! of a non-negative integer.\nDefined as n * (n-1) * ... * 1, with 0! = 1."
+              timeout: 15000
+              screenshot: "basecamp-method-docs.png"
         post_text: |
           The result `8` comes back from `calc_module`: pressing **Add** calls `logos.callModule("calc_module", "add", [3, 5])`, which basecamp routes to your core module and back to the QML view. Both modules — the `calc_module` core plugin and the `calc_ui` view plugin — are loaded from the `basecamp-data` directory you installed them into.
+
+          The **Methods** screen (Modules → Core Modules → *View Methods*) lists each method with the `description` from its doc comment — the same docs `lm` and `logoscore module-info` showed in Part 1, here in the GUI. `factorial`'s two `///` lines render as two lines, exactly as written.
 
           The sidebar labels each UI plugin by its `name` from `metadata.json`, which is why the tab reads `calc_ui`.
 

--- a/tests/tutorial-wrapping-c-library.test.yaml
+++ b/tests/tutorial-wrapping-c-library.test.yaml
@@ -373,9 +373,9 @@ sections:
                 // A doc comment directly above a method becomes that method's
                 // `description` in getMethods() — surfaced by `lm`, `logoscore
                 // module-info`, and Basecamp's Methods list. Use `///` (one or
-                // more lines) or a `/** ... */` block; a multi-line comment is
-                // joined into a single description. (Plain `//` comments like this
-                // block are ignored, so they never leak into the API.)
+                // more lines) or a `/** ... */` block; the comment's line breaks
+                // are preserved. (Plain `//` comments like this block are
+                // ignored, so they never leak into the API.)
 
                 /// Adds two integers and returns the sum.
                 int64_t add(int64_t a, int64_t b);
@@ -383,7 +383,7 @@ sections:
                 /// Multiplies two integers and returns the product.
                 int64_t multiply(int64_t a, int64_t b);
 
-                // A multi-line description: consecutive `///` lines are joined.
+                // A multi-line description: consecutive `///` lines keep their breaks.
                 /// Computes the factorial n! of a non-negative integer.
                 /// Defined as n * (n-1) * ... * 1, with 0! = 1.
                 int64_t factorial(int64_t n);
@@ -391,7 +391,7 @@ sections:
                 /// Returns the nth Fibonacci number (0-indexed).
                 int64_t fibonacci(int64_t n);
 
-                // A `/** ... */` block comment works too (also joined to one line).
+                // A `/** ... */` block comment works too (line breaks preserved).
                 /**
                  * Returns the version string of the wrapped libcalc C library.
                  * Read straight from the linked native library, not metadata.json.
@@ -595,12 +595,13 @@ sections:
           - "int fibonacci(int n)"
           - "QString libVersion()"
           - "Description: Adds two integers and returns the sum."
-          - "Description: Computes the factorial n! of a non-negative integer. Defined as n * (n-1) * ... * 1, with 0! = 1."
-          - "Description: Returns the version string of the wrapped libcalc C library. Read straight from the linked native library, not metadata.json."
+          - "Defined as n * (n-1) * ... * 1, with 0! = 1."
+          - "Read straight from the linked native library, not metadata.json."
         post_text: |
-          Output — each method you declared, with its doc comment shown on a
-          `Description:` line. Note `factorial` (two `///` lines) and `libVersion`
-          (a `/** ... */` block) are each joined into a single description:
+          Output — each method you declared, with its doc comment as a
+          `Description`. A single-line comment renders inline; a multi-line
+          comment (`factorial`'s two `///` lines, `libVersion`'s `/** ... */`
+          block, and `libVersionNotify`'s two `///` lines) keeps its line breaks:
 
           ```
           Plugin Methods:
@@ -619,7 +620,9 @@ sections:
           int factorial(int n)
             Signature: factorial(int)
             Invokable: yes
-            Description: Computes the factorial n! of a non-negative integer. Defined as n * (n-1) * ... * 1, with 0! = 1.
+            Description:
+              Computes the factorial n! of a non-negative integer.
+              Defined as n * (n-1) * ... * 1, with 0! = 1.
 
           int fibonacci(int n)
             Signature: fibonacci(int)
@@ -629,19 +632,23 @@ sections:
           QString libVersion()
             Signature: libVersion()
             Invokable: yes
-            Description: Returns the version string of the wrapped libcalc C library. Read straight from the linked native library, not metadata.json.
+            Description:
+              Returns the version string of the wrapped libcalc C library.
+              Read straight from the linked native library, not metadata.json.
 
           void libVersionNotify()
             Signature: libVersionNotify()
             Invokable: yes
-            Description: Looks up the library version and emits it as a `versionReady` event instead of returning it. Used by the QML tutorial (Part 2).
+            Description:
+              Looks up the library version and emits it as a `versionReady`
+              event instead of returning it. Used by the QML tutorial (Part 2).
           ```
 
           Three things to notice:
 
           - **Signatures are Qt-typed** (`int`, `QString`) even though you wrote `int64_t` / `std::string`. That's the generated glue: `lm` reports the wire types the synthesized Qt plugin exposes, so `int64_t add(int64_t, int64_t)` shows up as `add(int,int)`.
-          - **Each `Description:` line is your doc comment**, carried through the module's `getMethods()` introspection. Plain `//` comments (like the type-mapping note in the header) are deliberately ignored, so only intentional docs surface; an undocumented method simply omits the line.
-          - **Multi-line comments are joined into one line** — `factorial`'s two `///` lines and `libVersion`'s `/** ... */` block each become a single `description`. The same descriptions appear in `logoscore module-info` and Basecamp's Methods list.
+          - **Each `Description` is your doc comment**, carried through the module's `getMethods()` introspection. Plain `//` comments (like the type-mapping note in the header) are deliberately ignored, so only intentional docs surface; an undocumented method simply omits it.
+          - **Line breaks are preserved** — a single-line comment renders inline; a multi-line comment (`factorial`, `libVersion`, `libVersionNotify`) keeps its breaks. The same descriptions appear in `logoscore module-info` and Basecamp's Methods list.
 
       - title: "JSON output"
         text: "For scripting and CI, use `--json`:"
@@ -673,8 +680,11 @@ sections:
           ]
           ```
 
-          The `description` field is the method's `///` doc comment. Methods
-          without a doc comment omit it.
+          The `description` field is the method's doc comment. A multi-line
+          comment is carried verbatim with embedded `\n` (e.g. `factorial`:
+          `"Computes the factorial n! of a non-negative integer.\nDefined as
+          n * (n-1) * ... * 1, with 0! = 1."`). Methods without a doc comment
+          omit the field.
 
   # ── Step 6: Test with logoscore ─────────────────────────────────────────────
   - title: "Test with `logoscore`"
@@ -714,8 +724,9 @@ sections:
         run: "./logos/bin/logoscore module-info calc_module"
         expect_contains:
           - "Adds two integers and returns the sum."
-          - "Computes the factorial n! of a non-negative integer. Defined as n * (n-1) * ... * 1, with 0! = 1."
-          - "Returns the version string of the wrapped libcalc C library. Read straight from the linked native library, not metadata.json."
+          - "Computes the factorial n! of a non-negative integer."
+          - "Defined as n * (n-1) * ... * 1, with 0! = 1."
+          - "Read straight from the linked native library, not metadata.json."
         post_text: |
           ```
           Name:          calc_module
@@ -730,19 +741,22 @@ sections:
             multiply(a: int, b: int) -> int
                 Multiplies two integers and returns the product.
             factorial(n: int) -> int
-                Computes the factorial n! of a non-negative integer. Defined as n * (n-1) * ... * 1, with 0! = 1.
+                Computes the factorial n! of a non-negative integer.
+                Defined as n * (n-1) * ... * 1, with 0! = 1.
             fibonacci(n: int) -> int
                 Returns the nth Fibonacci number (0-indexed).
             libVersion() -> QString
-                Returns the version string of the wrapped libcalc C library. Read straight from the linked native library, not metadata.json.
+                Returns the version string of the wrapped libcalc C library.
+                Read straight from the linked native library, not metadata.json.
             libVersionNotify() -> void
-                Looks up the library version and emits it as a `versionReady` event instead of returning it. Used by the QML tutorial (Part 2).
+                Looks up the library version and emits it as a `versionReady`
+                event instead of returning it. Used by the QML tutorial (Part 2).
           ```
 
-          The `factorial` and `libVersion` descriptions show how a multi-line doc
-          comment (multiple `///` lines or a `/** ... */` block) is joined into one
-          line. An undocumented method would still appear, just without the
-          indented description line.
+          `factorial`, `libVersion`, and `libVersionNotify` show how a multi-line
+          doc comment (multiple `///` lines or a `/** ... */` block) keeps its line
+          breaks. An undocumented method would still appear, just without the
+          indented description.
 
       - title: "Call methods"
         text: "Now call them:"

--- a/tests/tutorial-wrapping-c-library.test.yaml
+++ b/tests/tutorial-wrapping-c-library.test.yaml
@@ -370,10 +370,12 @@ sections:
                 // The generator maps C++ types onto the wire automatically:
                 //   int64_t  ↔ int      std::string ↔ QString      bool ↔ bool
                 //
-                // A `///` doc comment directly above a method becomes that method's
+                // A doc comment directly above a method becomes that method's
                 // `description` in getMethods() — surfaced by `lm`, `logoscore
-                // module-info`, and Basecamp's Methods list. (Plain `//` comments
-                // like this block are ignored, so they never leak into the API.)
+                // module-info`, and Basecamp's Methods list. Use `///` (one or
+                // more lines) or a `/** ... */` block; a multi-line comment is
+                // joined into a single description. (Plain `//` comments like this
+                // block are ignored, so they never leak into the API.)
 
                 /// Adds two integers and returns the sum.
                 int64_t add(int64_t a, int64_t b);
@@ -381,13 +383,19 @@ sections:
                 /// Multiplies two integers and returns the product.
                 int64_t multiply(int64_t a, int64_t b);
 
+                // A multi-line description: consecutive `///` lines are joined.
                 /// Computes the factorial n! of a non-negative integer.
+                /// Defined as n * (n-1) * ... * 1, with 0! = 1.
                 int64_t factorial(int64_t n);
 
                 /// Returns the nth Fibonacci number (0-indexed).
                 int64_t fibonacci(int64_t n);
 
-                /// Returns the version string of the wrapped libcalc C library.
+                // A `/** ... */` block comment works too (also joined to one line).
+                /**
+                 * Returns the version string of the wrapped libcalc C library.
+                 * Read straight from the linked native library, not metadata.json.
+                 */
                 std::string libVersion();
 
                 /// Looks up the library version and emits it as a `versionReady`
@@ -587,10 +595,12 @@ sections:
           - "int fibonacci(int n)"
           - "QString libVersion()"
           - "Description: Adds two integers and returns the sum."
-          - "Description: Returns the version string of the wrapped libcalc C library."
+          - "Description: Computes the factorial n! of a non-negative integer. Defined as n * (n-1) * ... * 1, with 0! = 1."
+          - "Description: Returns the version string of the wrapped libcalc C library. Read straight from the linked native library, not metadata.json."
         post_text: |
-          Output — each method you declared, with its `///` doc comment shown on a
-          `Description:` line:
+          Output — each method you declared, with its doc comment shown on a
+          `Description:` line. Note `factorial` (two `///` lines) and `libVersion`
+          (a `/** ... */` block) are each joined into a single description:
 
           ```
           Plugin Methods:
@@ -609,7 +619,7 @@ sections:
           int factorial(int n)
             Signature: factorial(int)
             Invokable: yes
-            Description: Computes the factorial n! of a non-negative integer.
+            Description: Computes the factorial n! of a non-negative integer. Defined as n * (n-1) * ... * 1, with 0! = 1.
 
           int fibonacci(int n)
             Signature: fibonacci(int)
@@ -619,7 +629,7 @@ sections:
           QString libVersion()
             Signature: libVersion()
             Invokable: yes
-            Description: Returns the version string of the wrapped libcalc C library.
+            Description: Returns the version string of the wrapped libcalc C library. Read straight from the linked native library, not metadata.json.
 
           void libVersionNotify()
             Signature: libVersionNotify()
@@ -627,10 +637,11 @@ sections:
             Description: Looks up the library version and emits it as a `versionReady` event instead of returning it. Used by the QML tutorial (Part 2).
           ```
 
-          Two things to notice:
+          Three things to notice:
 
           - **Signatures are Qt-typed** (`int`, `QString`) even though you wrote `int64_t` / `std::string`. That's the generated glue: `lm` reports the wire types the synthesized Qt plugin exposes, so `int64_t add(int64_t, int64_t)` shows up as `add(int,int)`.
-          - **Each `Description:` line is your `///` doc comment**, carried through the module's `getMethods()` introspection. Plain `//` comments (like the type-mapping note in the header) are deliberately ignored, so only intentional docs surface; an undocumented method simply omits the line. The same descriptions appear in `logoscore module-info` and Basecamp's Methods list.
+          - **Each `Description:` line is your doc comment**, carried through the module's `getMethods()` introspection. Plain `//` comments (like the type-mapping note in the header) are deliberately ignored, so only intentional docs surface; an undocumented method simply omits the line.
+          - **Multi-line comments are joined into one line** — `factorial`'s two `///` lines and `libVersion`'s `/** ... */` block each become a single `description`. The same descriptions appear in `logoscore module-info` and Basecamp's Methods list.
 
       - title: "JSON output"
         text: "For scripting and CI, use `--json`:"
@@ -699,11 +710,12 @@ sections:
       - run: "./logos/bin/logoscore load-module calc_module"
 
       - title: "Inspect methods and their docs"
-        text: "`module-info` lists each method with its signature and the `///` description you wrote — the same docs `lm` showed, here straight from the module's `getPluginMethods` introspection:"
+        text: "`module-info` lists each method with its signature and the doc-comment description you wrote — the same docs `lm` showed, here straight from the module's `getPluginMethods` introspection:"
         run: "./logos/bin/logoscore module-info calc_module"
         expect_contains:
           - "Adds two integers and returns the sum."
-          - "Returns the version string of the wrapped libcalc C library."
+          - "Computes the factorial n! of a non-negative integer. Defined as n * (n-1) * ... * 1, with 0! = 1."
+          - "Returns the version string of the wrapped libcalc C library. Read straight from the linked native library, not metadata.json."
         post_text: |
           ```
           Name:          calc_module
@@ -718,17 +730,19 @@ sections:
             multiply(a: int, b: int) -> int
                 Multiplies two integers and returns the product.
             factorial(n: int) -> int
-                Computes the factorial n! of a non-negative integer.
+                Computes the factorial n! of a non-negative integer. Defined as n * (n-1) * ... * 1, with 0! = 1.
             fibonacci(n: int) -> int
                 Returns the nth Fibonacci number (0-indexed).
             libVersion() -> QString
-                Returns the version string of the wrapped libcalc C library.
+                Returns the version string of the wrapped libcalc C library. Read straight from the linked native library, not metadata.json.
             libVersionNotify() -> void
                 Looks up the library version and emits it as a `versionReady` event instead of returning it. Used by the QML tutorial (Part 2).
           ```
 
-          An undocumented method would still appear, just without the indented
-          description line.
+          The `factorial` and `libVersion` descriptions show how a multi-line doc
+          comment (multiple `///` lines or a `/** ... */` block) is joined into one
+          line. An undocumented method would still appear, just without the
+          indented description line.
 
       - title: "Call methods"
         text: "Now call them:"

--- a/tests/tutorial-wrapping-c-library.test.yaml
+++ b/tests/tutorial-wrapping-c-library.test.yaml
@@ -369,14 +369,29 @@ sections:
                 // ── Public API — every method here is callable over IPC ──────────
                 // The generator maps C++ types onto the wire automatically:
                 //   int64_t  ↔ int      std::string ↔ QString      bool ↔ bool
+                //
+                // A `///` doc comment directly above a method becomes that method's
+                // `description` in getMethods() — surfaced by `lm`, `logoscore
+                // module-info`, and Basecamp's Methods list. (Plain `//` comments
+                // like this block are ignored, so they never leak into the API.)
+
+                /// Adds two integers and returns the sum.
                 int64_t add(int64_t a, int64_t b);
+
+                /// Multiplies two integers and returns the product.
                 int64_t multiply(int64_t a, int64_t b);
+
+                /// Computes the factorial n! of a non-negative integer.
                 int64_t factorial(int64_t n);
+
+                /// Returns the nth Fibonacci number (0-indexed).
                 int64_t fibonacci(int64_t n);
+
+                /// Returns the version string of the wrapped libcalc C library.
                 std::string libVersion();
 
-                // Fire-and-forget: looks up the version, then emits it as an event
-                // instead of returning it. Used by the QML tutorial (Part 2).
+                /// Looks up the library version and emits it as a `versionReady`
+                /// event instead of returning it. Used by the QML tutorial (Part 2).
                 void libVersionNotify();
 
                 // ── Events ───────────────────────────────────────────────────────
@@ -407,6 +422,7 @@ sections:
             | `StdLogosResult`            | `LogosResult` (from `<logos_result.h>`) — `{ success, value, error }` |
 
           - Use `int64_t` for integers (not `int`) — that's the type the parser recognizes.
+          - **Document methods with `///`.** A doc comment (`///` or `/** … */`) directly above a method becomes its `description` in the module's introspection, surfaced by `lm`, `logoscore module-info`, and Basecamp. Plain `//` comments are ignored, so only intentional docs are exposed — you'll see this in action in Step 5.
           - Events are declared in a `logos_events:` section. The token is recognized by the generator before preprocessing; under a normal compile it just expands to `public`.
 
       - title: "`src/calc_module_impl.cpp` — Implementation"
@@ -570,49 +586,51 @@ sections:
           - "int factorial(int n)"
           - "int fibonacci(int n)"
           - "QString libVersion()"
+          - "Description: Adds two integers and returns the sum."
+          - "Description: Returns the version string of the wrapped libcalc C library."
         post_text: |
-          Output:
+          Output — each method you declared, with its `///` doc comment shown on a
+          `Description:` line:
 
           ```
           Plugin Methods:
           ===============
 
-          void eventResponse(QString eventName, QVariantList args)
-            Signature: eventResponse(QString,QVariantList)
-            Invokable: no
-
-          void initLogos(LogosAPI* api)
-            Signature: initLogos(LogosAPI*)
-            Invokable: yes
-
           int add(int a, int b)
             Signature: add(int,int)
             Invokable: yes
+            Description: Adds two integers and returns the sum.
 
           int multiply(int a, int b)
             Signature: multiply(int,int)
             Invokable: yes
+            Description: Multiplies two integers and returns the product.
 
           int factorial(int n)
             Signature: factorial(int)
             Invokable: yes
+            Description: Computes the factorial n! of a non-negative integer.
 
           int fibonacci(int n)
             Signature: fibonacci(int)
             Invokable: yes
+            Description: Returns the nth Fibonacci number (0-indexed).
 
           QString libVersion()
             Signature: libVersion()
             Invokable: yes
+            Description: Returns the version string of the wrapped libcalc C library.
 
           void libVersionNotify()
             Signature: libVersionNotify()
             Invokable: yes
+            Description: Looks up the library version and emits it as a `versionReady` event instead of returning it. Used by the QML tutorial (Part 2).
           ```
 
-          Notice the signatures are **Qt-typed** (`int`, `QString`) even though you wrote `int64_t` / `std::string`. That's the generated glue at work: `lm` is inspecting the synthesized Qt plugin, not your impl class. Your `int64_t add(int64_t, int64_t)` shows up on the wire as `add(int,int)`.
+          Two things to notice:
 
-          The `eventResponse` signal and `initLogos` method are also part of the generated wrapper — you didn't write them. `initLogos` is how the host hands the module its `LogosAPI`; `eventResponse` is the channel your `versionReady` event travels over. Both come for free with `interface: universal`.
+          - **Signatures are Qt-typed** (`int`, `QString`) even though you wrote `int64_t` / `std::string`. That's the generated glue: `lm` reports the wire types the synthesized Qt plugin exposes, so `int64_t add(int64_t, int64_t)` shows up as `add(int,int)`.
+          - **Each `Description:` line is your `///` doc comment**, carried through the module's `getMethods()` introspection. Plain `//` comments (like the type-mapping note in the header) are deliberately ignored, so only intentional docs surface; an undocumented method simply omits the line. The same descriptions appear in `logoscore module-info` and Basecamp's Methods list.
 
       - title: "JSON output"
         text: "For scripting and CI, use `--json`:"
@@ -625,10 +643,12 @@ sections:
           ./lm/bin/lm methods result/lib/calc_module_plugin.dylib --json
         expect_contains:
           - '"name": "add"'
+          - '"description": "Adds two integers and returns the sum."'
         post_text: |
           ```json
           [
               {
+                  "description": "Adds two integers and returns the sum.",
                   "isInvokable": true,
                   "name": "add",
                   "parameters": [
@@ -641,6 +661,9 @@ sections:
               ...
           ]
           ```
+
+          The `description` field is the method's `///` doc comment. Methods
+          without a doc comment omit it.
 
   # ── Step 6: Test with logoscore ─────────────────────────────────────────────
   - title: "Test with `logoscore`"
@@ -667,15 +690,49 @@ sections:
           └── variant                    # Platform variant identifier
           ```
 
-      - title: "Call methods"
-        text: "Start the daemon and call methods:"
+      - title: "Start the daemon and load the module"
+        text: "Start the daemon and load `calc_module`:"
         run: "./logos/bin/logoscore -D -m ./modules &"
 
       - run: "sleep 3"
 
       - run: "./logos/bin/logoscore load-module calc_module"
 
-      - run: "./logos/bin/logoscore call calc_module add 3 5"
+      - title: "Inspect methods and their docs"
+        text: "`module-info` lists each method with its signature and the `///` description you wrote — the same docs `lm` showed, here straight from the module's `getPluginMethods` introspection:"
+        run: "./logos/bin/logoscore module-info calc_module"
+        expect_contains:
+          - "Adds two integers and returns the sum."
+          - "Returns the version string of the wrapped libcalc C library."
+        post_text: |
+          ```
+          Name:          calc_module
+          Version:       v1.0.0
+          Status:        loaded
+          PID:           48213
+          Uptime:        3s
+
+          Methods:
+            add(a: int, b: int) -> int
+                Adds two integers and returns the sum.
+            multiply(a: int, b: int) -> int
+                Multiplies two integers and returns the product.
+            factorial(n: int) -> int
+                Computes the factorial n! of a non-negative integer.
+            fibonacci(n: int) -> int
+                Returns the nth Fibonacci number (0-indexed).
+            libVersion() -> QString
+                Returns the version string of the wrapped libcalc C library.
+            libVersionNotify() -> void
+                Looks up the library version and emits it as a `versionReady` event instead of returning it. Used by the QML tutorial (Part 2).
+          ```
+
+          An undocumented method would still appear, just without the indented
+          description line.
+
+      - title: "Call methods"
+        text: "Now call them:"
+        run: "./logos/bin/logoscore call calc_module add 3 5"
         expect_contains:
           - '"result":8'
 

--- a/tests/tutorial-wrapping-c-library.test.yaml
+++ b/tests/tutorial-wrapping-c-library.test.yaml
@@ -371,11 +371,11 @@ sections:
                 //   int64_t  ↔ int      std::string ↔ QString      bool ↔ bool
                 //
                 // A doc comment directly above a method becomes that method's
-                // `description` in getMethods() — surfaced by `lm`, `logoscore
-                // module-info`, and Basecamp's Methods list. Use `///` (one or
-                // more lines) or a `/** ... */` block; the comment's line breaks
-                // are preserved. (Plain `//` comments like this block are
-                // ignored, so they never leak into the API.)
+                // `description` in the module's method introspection — surfaced
+                // by `lm`, `logoscore module-info`, and Basecamp's Methods list.
+                // Use `///` (one or more lines) or a `/** ... */` block; the
+                // comment's line breaks are preserved. (Plain `//` comments like
+                // this block are ignored, so they never leak into the API.)
 
                 /// Adds two integers and returns the sum.
                 int64_t add(int64_t a, int64_t b);
@@ -647,7 +647,7 @@ sections:
           Three things to notice:
 
           - **Signatures are Qt-typed** (`int`, `QString`) even though you wrote `int64_t` / `std::string`. That's the generated glue: `lm` reports the wire types the synthesized Qt plugin exposes, so `int64_t add(int64_t, int64_t)` shows up as `add(int,int)`.
-          - **Each `Description` is your doc comment**, carried through the module's `getMethods()` introspection. Plain `//` comments (like the type-mapping note in the header) are deliberately ignored, so only intentional docs surface; an undocumented method simply omits it.
+          - **Each `Description` is your doc comment**, carried through the module's method introspection. Plain `//` comments (like the type-mapping note in the header) are deliberately ignored, so only intentional docs surface; an undocumented method simply omits it.
           - **Line breaks are preserved** — a single-line comment renders inline; a multi-line comment (`factorial`, `libVersion`, `libVersionNotify`) keeps its breaks. The same descriptions appear in `logoscore module-info` and Basecamp's Methods list.
 
       - title: "JSON output"
@@ -720,7 +720,7 @@ sections:
       - run: "./logos/bin/logoscore load-module calc_module"
 
       - title: "Inspect methods and their docs"
-        text: "`module-info` lists each method with its signature and the doc-comment description you wrote — the same docs `lm` showed, here straight from the module's `getPluginMethods` introspection:"
+        text: "`module-info` lists each method with its signature and the doc-comment description you wrote — the same docs `lm` showed, here straight from the module's method introspection:"
         run: "./logos/bin/logoscore module-info calc_module"
         expect_contains:
           - "Adds two integers and returns the sum."


### PR DESCRIPTION
## What

- Add `///` doc comments to the calc module's methods in the wrapping-c-library tutorial.
- Assert they surface via `lm methods` (human + `--json`) **and** `logoscore module-info` (new step).
- Correct the stale `lm` output (provider-path introspection lists only impl methods, not `eventResponse`/`initLogos`). Regenerated the tutorial markdown.

## Note
These assertions exercise the description feature, which lives in the coordinated `parse-method-comments-as-description` set (logos-cpp-sdk + logos-module + logos-logoscore-cli). They go green once those land in a release the tutorial runs against — verified here via `./run.sh --release-for …=parse-method-comments-as-description` (**68 passed, 0 failed**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)