### PR TITLE
Document + verify event introspection in the tutorials

### DIFF
--- a/outputs/tutorial-qml-ui-app.md
+++ b/outputs/tutorial-qml-ui-app.md
@@ -627,15 +627,16 @@ Launch basecamp pointed at that data directory. The `calc_ui` plugin appears in 
 
 ![calc_module returns 3 + 5 = 8](images/basecamp-calc-installed.png)
 
-The doc comments you wrote on `calc_module`'s methods in Part 1 also
-surface in basecamp. Open **Modules → Core Modules**, then view
-`calc_module`'s methods — each method shows its `description`.
+The doc comments you wrote on `calc_module`'s methods and events in
+Part 1 also surface in basecamp. Open **Modules → Core Modules**, then
+open `calc_module`'s **Interface** — each method and event shows its
+`description`.
 
-![Per-method descriptions render (single- and multi-line)](images/basecamp-method-docs.png)
+![Method and event descriptions render (single- and multi-line)](images/basecamp-interface-docs.png)
 
 The result `8` comes back from `calc_module`: pressing **Add** calls `logos.callModule("calc_module", "add", [3, 5])`, which basecamp routes to your core module and back to the QML view. Both modules — the `calc_module` core plugin and the `calc_ui` view plugin — are loaded from the `basecamp-data` directory you installed them into.
 
-The **Methods** screen (Modules → Core Modules → *View Methods*) lists each method with the `description` from its doc comment — the same docs `lm` and `logoscore module-info` showed in Part 1, here in the GUI. `factorial`'s two `///` lines render as two lines, exactly as written.
+The **Interface** screen (Modules → Core Modules → *Interface*) lists every method **and event** with the `description` from its doc comment — the same docs `lm` and `logoscore module-info` showed in Part 1, here in the GUI. Multi-line `///` comments render as multiple lines, exactly as written.
 
 The sidebar labels each UI plugin by its `name` from `metadata.json`, which is why the tab reads `calc_ui`.
 

--- a/outputs/tutorial-wrapping-c-library.md
+++ b/outputs/tutorial-wrapping-c-library.md
@@ -408,7 +408,13 @@ public:
     // calc_module_events.cpp) that routes the typed args to subscribers
     // via the host's `eventResponse` mechanism. QML subscribes with
     // logos.onModuleEvent("calc_module", "versionReady").
+    //
+    // A `///` doc comment documents the event too — it surfaces as the
+    // event's `description` alongside methods (`lm events`, `logoscore
+    // module-info`, and Basecamp's Interface screen).
 logos_events:
+    /// Emitted by libVersionNotify() once the library version is known.
+    /// Carries the version string read from libcalc.
     void versionReady(const std::string& version);
 };
 ```
@@ -696,6 +702,36 @@ comment is carried verbatim with embedded `\n` (e.g. `factorial`:
 n * (n-1) * ... * 1, with 0! = 1."`). Methods without a doc comment
 omit the field.
 
+### 5.5 List events
+
+Events (your `logos_events:` block) are part of the module's API too, and
+are introspectable the same way — `lm events` lists each event with its
+signature and `///` description:
+
+```bash
+# Linux
+./lm/bin/lm events result/lib/calc_module_plugin.so
+
+# macOS
+./lm/bin/lm events result/lib/calc_module_plugin.dylib
+```
+
+```
+Plugin Events:
+==============
+
+void versionReady(QString version)
+  Signature: versionReady(QString)
+  Description:
+    Emitted by libVersionNotify() once the library version is known.
+    Carries the version string read from libcalc.
+```
+
+Events have no return type (they're fire-and-forget). Running `lm`
+with no subcommand prints metadata, methods, **and** events together.
+The same event docs appear in `logoscore module-info` and Basecamp's
+Interface screen.
+
 ---
 
 ## Step 6: Test with `logoscore`
@@ -752,9 +788,9 @@ sleep 3
 ./logos/bin/logoscore load-module calc_module
 ```
 
-### 6.4 Inspect methods and their docs
+### 6.4 Inspect methods and events
 
-`module-info` lists each method with its signature and the doc-comment description you wrote — the same docs `lm` showed, here straight from the module's method introspection:
+`module-info` lists each method **and event** with its signature and the doc-comment description you wrote — the same docs `lm` showed, here straight from the module's introspection:
 
 ```bash
 ./logos/bin/logoscore module-info calc_module
@@ -783,12 +819,16 @@ Methods:
   libVersionNotify() -> void
       Looks up the library version and emits it as a `versionReady`
       event instead of returning it. Used by the QML tutorial (Part 2).
+
+Events:
+  versionReady(version: QString)
+      Emitted by libVersionNotify() once the library version is known.
+      Carries the version string read from libcalc.
 ```
 
-`factorial`, `libVersion`, and `libVersionNotify` show how a multi-line
-doc comment (multiple `///` lines or a `/** ... */` block) keeps its line
-breaks. An undocumented method would still appear, just without the
-indented description.
+Methods and events both show their doc comments (multi-line ones keep
+their line breaks). An undocumented method or event still appears, just
+without the indented description.
 
 ### 6.5 Call methods
 

--- a/tests/tutorial-qml-ui-app.test.yaml
+++ b/tests/tutorial-qml-ui-app.test.yaml
@@ -674,12 +674,13 @@ sections:
               texts: ["8"]
               timeout: 10000
               screenshot: "basecamp-calc-installed.png"
-            # ── Verify the `///` method docs surface on the Methods screen ──────
+            # ── Verify the `///` method + event docs surface on the Interface screen ──
             - name: "Open the Modules system view"
               text: |
-                The doc comments you wrote on `calc_module`'s methods in Part 1 also
-                surface in basecamp. Open **Modules → Core Modules**, then view
-                `calc_module`'s methods — each method shows its `description`.
+                The doc comments you wrote on `calc_module`'s methods and events in
+                Part 1 also surface in basecamp. Open **Modules → Core Modules**, then
+                open `calc_module`'s **Interface** — each method and event shows its
+                `description`.
               action: click
               target: "Modules"
             - name: "Switch to the Core Modules tab"
@@ -689,26 +690,27 @@ sections:
               action: wait_for
               texts: ["calc_module"]
               timeout: 15000
-            # Every module row's "View Methods" button shares the same label, so
-            # open calc_module's Methods screen by name via the view's
-            # openMethods() helper (equivalent to clicking its button).
-            - name: "Open calc_module's Methods screen"
+            # Every module row's "Interface" button shares the same label, so open
+            # calc_module's Interface screen by name via the view's openInterface()
+            # helper (equivalent to clicking its button).
+            - name: "Open calc_module's Interface screen"
               action: call_method
               find_by: "objectName"
               find_value: "coreModulesView"
-              method: "openMethods"
+              method: "openInterface"
               args: ["calc_module"]
-            - name: "Per-method descriptions render (single- and multi-line)"
+            - name: "Method and event descriptions render (single- and multi-line)"
               action: wait_for
               texts:
                 - "Adds two integers and returns the sum."
                 - "Computes the factorial n! of a non-negative integer.\nDefined as n * (n-1) * ... * 1, with 0! = 1."
+                - "Emitted by libVersionNotify() once the library version is known.\nCarries the version string read from libcalc."
               timeout: 15000
-              screenshot: "basecamp-method-docs.png"
+              screenshot: "basecamp-interface-docs.png"
         post_text: |
           The result `8` comes back from `calc_module`: pressing **Add** calls `logos.callModule("calc_module", "add", [3, 5])`, which basecamp routes to your core module and back to the QML view. Both modules — the `calc_module` core plugin and the `calc_ui` view plugin — are loaded from the `basecamp-data` directory you installed them into.
 
-          The **Methods** screen (Modules → Core Modules → *View Methods*) lists each method with the `description` from its doc comment — the same docs `lm` and `logoscore module-info` showed in Part 1, here in the GUI. `factorial`'s two `///` lines render as two lines, exactly as written.
+          The **Interface** screen (Modules → Core Modules → *Interface*) lists every method **and event** with the `description` from its doc comment — the same docs `lm` and `logoscore module-info` showed in Part 1, here in the GUI. Multi-line `///` comments render as multiple lines, exactly as written.
 
           The sidebar labels each UI plugin by its `name` from `metadata.json`, which is why the tab reads `calc_ui`.
 

--- a/tests/tutorial-wrapping-c-library.test.yaml
+++ b/tests/tutorial-wrapping-c-library.test.yaml
@@ -407,7 +407,13 @@ sections:
                 // calc_module_events.cpp) that routes the typed args to subscribers
                 // via the host's `eventResponse` mechanism. QML subscribes with
                 // logos.onModuleEvent("calc_module", "versionReady").
+                //
+                // A `///` doc comment documents the event too — it surfaces as the
+                // event's `description` alongside methods (`lm events`, `logoscore
+                // module-info`, and Basecamp's Interface screen).
             logos_events:
+                /// Emitted by libVersionNotify() once the library version is known.
+                /// Carries the version string read from libcalc.
                 void versionReady(const std::string& version);
             };
         post_text: |
@@ -686,6 +692,39 @@ sections:
           n * (n-1) * ... * 1, with 0! = 1."`). Methods without a doc comment
           omit the field.
 
+      - title: "List events"
+        text: |
+          Events (your `logos_events:` block) are part of the module's API too, and
+          are introspectable the same way — `lm events` lists each event with its
+          signature and `///` description:
+        run: "./lm/bin/lm events result/lib/calc_module_plugin.{ext}"
+        code_block: |
+          # Linux
+          ./lm/bin/lm events result/lib/calc_module_plugin.so
+
+          # macOS
+          ./lm/bin/lm events result/lib/calc_module_plugin.dylib
+        expect_contains:
+          - "void versionReady(QString version)"
+          - "Emitted by libVersionNotify() once the library version is known."
+          - "Carries the version string read from libcalc."
+        post_text: |
+          ```
+          Plugin Events:
+          ==============
+
+          void versionReady(QString version)
+            Signature: versionReady(QString)
+            Description:
+              Emitted by libVersionNotify() once the library version is known.
+              Carries the version string read from libcalc.
+          ```
+
+          Events have no return type (they're fire-and-forget). Running `lm`
+          with no subcommand prints metadata, methods, **and** events together.
+          The same event docs appear in `logoscore module-info` and Basecamp's
+          Interface screen.
+
   # ── Step 6: Test with logoscore ─────────────────────────────────────────────
   - title: "Test with `logoscore`"
     step: true
@@ -719,14 +758,16 @@ sections:
 
       - run: "./logos/bin/logoscore load-module calc_module"
 
-      - title: "Inspect methods and their docs"
-        text: "`module-info` lists each method with its signature and the doc-comment description you wrote — the same docs `lm` showed, here straight from the module's method introspection:"
+      - title: "Inspect methods and events"
+        text: "`module-info` lists each method **and event** with its signature and the doc-comment description you wrote — the same docs `lm` showed, here straight from the module's introspection:"
         run: "./logos/bin/logoscore module-info calc_module"
         expect_contains:
           - "Adds two integers and returns the sum."
           - "Computes the factorial n! of a non-negative integer."
           - "Defined as n * (n-1) * ... * 1, with 0! = 1."
           - "Read straight from the linked native library, not metadata.json."
+          - "Emitted by libVersionNotify() once the library version is known."
+          - "Carries the version string read from libcalc."
         post_text: |
           ```
           Name:          calc_module
@@ -751,12 +792,16 @@ sections:
             libVersionNotify() -> void
                 Looks up the library version and emits it as a `versionReady`
                 event instead of returning it. Used by the QML tutorial (Part 2).
+
+          Events:
+            versionReady(version: QString)
+                Emitted by libVersionNotify() once the library version is known.
+                Carries the version string read from libcalc.
           ```
 
-          `factorial`, `libVersion`, and `libVersionNotify` show how a multi-line
-          doc comment (multiple `///` lines or a `/** ... */` block) keeps its line
-          breaks. An undocumented method would still appear, just without the
-          indented description.
+          Methods and events both show their doc comments (multi-line ones keep
+          their line breaks). An undocumented method or event still appears, just
+          without the indented description.
 
       - title: "Call methods"
         text: "Now call them:"


### PR DESCRIPTION
## What

Mirror the per-method documentation coverage for events. Part of the per-event documentation feature (see logos-cpp-sdk#71). The wrapping-c-library `calc_module` already emits a `versionReady` event; this gives it a `///` doc comment and asserts the whole event pipeline end-to-end through the doctest.

## Changes

- **`tutorial-wrapping-c-library.test.yaml`** — document the `versionReady` event; add a **"List events"** step asserting `lm events` shows `void versionReady(QString version)` + both description lines; assert `logoscore module-info`'s **Events** section.
- **`tutorial-qml-ui-app.test.yaml`** — rename the Basecamp `ui_test` driver call `openMethods` → `openInterface` and assert the event's description renders on the **Interface** screen (`basecamp-interface-docs.png`).
- Regenerated both tutorial `.md`s.

## Note

Executing these new assertions end-to-end requires the events-aware generator from logos-cpp-sdk#71 to be available to the module build (via logos-module-builder's cpp-sdk pin) — the same post-merge coordination the methods feature needed. `--release-for` overrides only the `{release}` GitHub refs, not transitive nix inputs, so the full green run lands once logos-cpp-sdk#71 is merged and module-builder re-pins it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)