### PR TITLE
fix(qml-ui): navigate Settings → Modules → Core Modules in basecamp

### DIFF
--- a/outputs/tutorial-qml-ui-app.md
+++ b/outputs/tutorial-qml-ui-app.md
@@ -628,15 +628,15 @@ Launch basecamp pointed at that data directory. The `calc_ui` plugin appears in 
 ![calc_module returns 3 + 5 = 8](images/basecamp-calc-installed.png)
 
 The doc comments you wrote on `calc_module`'s methods and events in
-Part 1 also surface in basecamp. Open **Modules → Core Modules**, then
-open `calc_module`'s **Interface** — each method and event shows its
-`description`.
+Part 1 also surface in basecamp. Open **Settings → Modules → Core
+Modules**, then open `calc_module`'s **Interface** — each method and
+event shows its `description`.
 
 ![Method and event descriptions render (single- and multi-line)](images/basecamp-interface-docs.png)
 
 The result `8` comes back from `calc_module`: pressing **Add** calls `logos.callModule("calc_module", "add", [3, 5])`, which basecamp routes to your core module and back to the QML view. Both modules — the `calc_module` core plugin and the `calc_ui` view plugin — are loaded from the `basecamp-data` directory you installed them into.
 
-The **Interface** screen (Modules → Core Modules → *Interface*) lists every method **and event** with the `description` from its doc comment — the same docs `lm` and `logoscore module-info` showed in Part 1, here in the GUI. Multi-line `///` comments render as multiple lines, exactly as written.
+The **Interface** screen (Settings → Modules → Core Modules → *Interface*) lists every method **and event** with the `description` from its doc comment — the same docs `lm` and `logoscore module-info` showed in Part 1, here in the GUI. Multi-line `///` comments render as multiple lines, exactly as written.
 
 The sidebar labels each UI plugin by its `name` from `metadata.json`, which is why the tab reads `calc_ui`.
 

--- a/tests/tutorial-qml-ui-app.test.yaml
+++ b/tests/tutorial-qml-ui-app.test.yaml
@@ -675,12 +675,22 @@ sections:
               timeout: 10000
               screenshot: "basecamp-calc-installed.png"
             # ── Verify the `///` method + event docs surface on the Interface screen ──
-            - name: "Open the Modules system view"
+            # The modules view now lives under Settings: the old top-level "Modules"
+            # sidebar entry was renamed to "Package Manager", so "Modules" is reached
+            # via Settings → Modules → (UI Modules / Core Modules).
+            - name: "Open Settings"
               text: |
                 The doc comments you wrote on `calc_module`'s methods and events in
-                Part 1 also surface in basecamp. Open **Modules → Core Modules**, then
-                open `calc_module`'s **Interface** — each method and event shows its
-                `description`.
+                Part 1 also surface in basecamp. Open **Settings → Modules → Core
+                Modules**, then open `calc_module`'s **Interface** — each method and
+                event shows its `description`.
+              action: click
+              target: "Settings"
+            - name: "Settings view loads"
+              action: wait_for
+              texts: ["Sections", "Modules"]
+              timeout: 30000
+            - name: "Open the Modules sub-tab"
               action: click
               target: "Modules"
             - name: "Switch to the Core Modules tab"
@@ -710,7 +720,7 @@ sections:
         post_text: |
           The result `8` comes back from `calc_module`: pressing **Add** calls `logos.callModule("calc_module", "add", [3, 5])`, which basecamp routes to your core module and back to the QML view. Both modules — the `calc_module` core plugin and the `calc_ui` view plugin — are loaded from the `basecamp-data` directory you installed them into.
 
-          The **Interface** screen (Modules → Core Modules → *Interface*) lists every method **and event** with the `description` from its doc comment — the same docs `lm` and `logoscore module-info` showed in Part 1, here in the GUI. Multi-line `///` comments render as multiple lines, exactly as written.
+          The **Interface** screen (Settings → Modules → Core Modules → *Interface*) lists every method **and event** with the `description` from its doc comment — the same docs `lm` and `logoscore module-info` showed in Part 1, here in the GUI. Multi-line `///` comments render as multiple lines, exactly as written.
 
           The sidebar labels each UI plugin by its `name` from `metadata.json`, which is why the tab reads `calc_ui`.
 


### PR DESCRIPTION
## What

The Part 2 (QML UI) doc-test step **"Launch basecamp and use the calculator"** fails when run against the current `logos-basecamp`:

```
click("Modules"): No element found with text 'Modules'
```

basecamp restructured its navigation — its own test spells it out ([`tests/ui-tests.mjs`](https://github.com/logos-co/logos-basecamp/blob/master/tests/ui-tests.mjs)):

> The old top-level **"Modules"** sidebar entry was renamed; the embedded ModulesView (UI Modules + Core Modules tabs) now lives under **Settings → Modules**.

The old top-level sidebar entry is now **"Package Manager"**, so a plain `click("Modules")` no longer resolves. basecamp builds, launches, and the inspector connects fine — the test just can't find the element it used to click.

## Fix

`tests/tutorial-qml-ui-app.test.yaml` — open **Settings** first (and wait for the Settings view to render), then click the now-nested **Modules** sub-tab, then **Core Modules**. This mirrors `logos-basecamp`'s own `basecamp-modules` doc-test, which clicks `Settings → Modules → Core Modules` with a plain `target: "Modules"` (unambiguous once inside Settings).

Prose updated to **Settings → Modules → Core Modules**, and `outputs/tutorial-qml-ui-app.md` regenerated via `doctest generate` (diff is exactly the two prose lines — the added navigation steps carry no narrative text).

## How it was found

The [logos-workspace nightly doc-test pipeline](https://github.com/logos-co/logos-workspace/pull/67) ran this tutorial spec against the bumped `logos-basecamp` commit and surfaced the drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)