### PR TITLE
docs: document the `nix build .#generate` output

### DIFF
--- a/logos-developer-guide.md
+++ b/logos-developer-guide.md
@@ -310,6 +310,11 @@ nix build .#lib
 # Build just the generated SDK headers (for other modules to use)
 nix build .#include
 
+# Emit a ready-to-build codebase: runs every code generator that is part of the
+# build and writes the module source + a fully-populated generated_code/ to
+# result/. Build it from `nix develop` without re-running any generator.
+nix build .#generate
+
 # Enter the dev shell for manual CMake builds (see: https://nix.dev/tutorials/first-steps/dev-environment)
 # The shell provides cmake, ninja, Qt, the Logos SDK, and all build dependencies.
 nix develop


### PR DESCRIPTION
Documents the new `nix build .#generate` flake output (module-builder) in the developer guide's build-outputs section: it runs every code generator that is part of the build and writes the module source + a fully-populated `generated_code/` to `result/`, buildable from `nix develop` without re-running any generator.

Docs-only; pairs with the feature PRs:
- logos-co/logos-plugin-qt#13 (backend generate mode)
- logos-co/logos-module-builder#123 (the `generate` output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)