### PR TITLE
ci: tutorial-v4 report snapshot (0.2.0-pinned) — do not merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
             tests/tutorial-interface-dependencies.test.yaml \
             --verbose \
             --continue-on-fail \
+            --release 0.2.0 \
             --report "${{ runner.temp }}/tutorial-report.html"
 
       - name: Stage report for upload


### PR DESCRIPTION
Snapshot-only PR to publish an immutable `pr-<N>` GitHub Pages report for the **tutorial-v4** release, so `logos-doctest-hub` can pin its `v4` version to it (same pattern v3 used with `pr-61`).

- The only change is adding `--release 0.2.0` to the report `doctest run` in `ci.yml`, so the published two-column report executes the tutorials against the **0.2.0** release tags.
- **Do not merge.** Once CI finishes and the `pr-<N>/<os>/` report is published, this PR can be closed — the Pages directory persists (`keep_files: true`) and the hub iframes it live.
- master deliberately stays unpinned so the nightly `main/` report keeps tracking edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)