### PR TITLE
fix(doctests): raise launch_timeout for the `nix run .` UI tests

### DIFF
--- a/tests/tutorial-cpp-ui-app.test.yaml
+++ b/tests/tutorial-cpp-ui-app.test.yaml
@@ -787,6 +787,10 @@ sections:
           setup:
             - "nix build 'github:logos-co/logos-qt-mcp{release}' -o result-mcp"
           qt_mcp: "result-mcp"
+          # `nix build .` (the runner's warm-up) builds the UI plugin, not
+          # `apps.default`'s standalone-app closure, so that still compiles
+          # during launch and can blow past the default 120s inspector wait.
+          launch_timeout: 900
           tests:
             - name: "App window opens with title"
               action: wait_for

--- a/tests/tutorial-qml-ui-app.test.yaml
+++ b/tests/tutorial-qml-ui-app.test.yaml
@@ -378,6 +378,13 @@ sections:
           setup:
             - "nix build 'github:logos-co/logos-qt-mcp{release}' -o result-mcp"
           qt_mcp: "result-mcp"
+          # The runner pre-builds `nix build .` — that is `packages.default`
+          # (the UI plugin). But `nix run .` launches `apps.default`, the
+          # standalone app, whose closure (logos-standalone-app + the bundled
+          # backend modules) is NOT covered by that warm build, so it compiles
+          # during launch. On a cold cache that exceeds the default 120s
+          # inspector wait and the app never boots before we give up.
+          launch_timeout: 900
           tests:
             - name: "App window opens with title"
               action: wait_for
@@ -446,6 +453,9 @@ sections:
           setup:
             - "nix build 'github:logos-co/logos-qt-mcp{release}' -o result-mcp"
           qt_mcp: "result-mcp"
+          # Overriding calc_module rebuilds the standalone app closure, which
+          # the `nix build` warm-up does not cover — see the note in Step 5.
+          launch_timeout: 900
           tests:
             - name: "App title visible"
               action: wait_for


### PR DESCRIPTION
## Why

The tutorial doc-test went red on ubuntu in the [nightly](https://github.com/logos-co/logos-workspace/actions/runs/29940760424) with:

```
inspector not available on port 3768 after 120s
```

and the last line of the launch log was `building '/nix/store/…-logos-standalone-app-1.0.0.drv'…` — the app was still **compiling** when the inspector clock expired. Nothing was actually broken.

The runner turns a `nix run .` launch into a `nix build .` warm-up, but that is `packages.default` — the **UI plugin**. `nix run .` launches `apps.default`, the **standalone app**, whose closure (`logos-standalone-app` + the bundled backend modules) is not in the plugin's build closure. So it compiles during launch, charged against the default 120s `launch_timeout`.

## What

Add `launch_timeout: 900` to the three `nix run` UI tests, with a comment explaining the gap. This is the same knob (and the same reason) the `logos-wallet-module` spec already documents.

`launch_timeout` is harness configuration — it is not rendered into the generated Markdown, so the tutorials themselves are unchanged.

## Note

The `nix build .`-vs-`apps.default` gap is really a harness-level shortcoming; raising the per-spec timeout is the same mitigation every other affected spec uses. A follow-up in `logos-doctest` could make the warm-up cover `apps.default` and remove the need for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)