### PR TITLE
fix(doctests): track the qlonglong type contract and Basecamp's renamed Module Inspector

### DIFF
--- a/tests/tutorial-qml-ui-app.test.yaml
+++ b/tests/tutorial-qml-ui-app.test.yaml
@@ -697,17 +697,14 @@ sections:
               action: wait_for
               texts: ["Sections"]
               timeout: 60000
-            - name: "Open the Modules system view"
+            - name: "Open the Module Inspector"
               text: |
                 The doc comments you wrote on `calc_module`'s methods and events in
-                Part 1 also surface in basecamp. Open **Settings → Modules → Core
-                Modules**, then open `calc_module`'s **Interface** — each method and
-                event shows its `description`.
+                Part 1 also surface in basecamp. Open **Settings → Module
+                Inspector**, then open `calc_module`'s **Interface** — each method
+                and event shows its `description`.
               action: click
-              target: "Modules"
-            - name: "Switch to the Core Modules tab"
-              action: click
-              target: "Core Modules"
+              target: "Module Inspector"
             - name: "calc_module is listed"
               action: wait_for
               texts: ["calc_module"]
@@ -718,7 +715,7 @@ sections:
             - name: "Open calc_module's Interface screen"
               action: call_method
               find_by: "objectName"
-              find_value: "coreModulesView"
+              find_value: "moduleInspectorView"
               method: "openInterface"
               args: ["calc_module"]
             - name: "Method and event descriptions render (single- and multi-line)"
@@ -732,7 +729,7 @@ sections:
         post_text: |
           The result `8` comes back from `calc_module`: pressing **Add** calls `logos.callModule("calc_module", "add", [3, 5])`, which basecamp routes to your core module and back to the QML view. Both modules — the `calc_module` core plugin and the `calc_ui` view plugin — are loaded from the `basecamp-data` directory you installed them into.
 
-          The **Interface** screen (Settings → Modules → Core Modules → *Interface*) lists every method **and event** with the `description` from its doc comment — the same docs `lm` and `logoscore module-info` showed in Part 1, here in the GUI. Multi-line `///` comments render as multiple lines, exactly as written.
+          The **Interface** screen (Settings → Module Inspector → *Interface*) lists every method **and event** with the `description` from its doc comment — the same docs `lm` and `logoscore module-info` showed in Part 1, here in the GUI. Multi-line `///` comments render as multiple lines, exactly as written.
 
           The sidebar labels each UI plugin by its `name` from `metadata.json`, which is why the tab reads `calc_ui`.
 

--- a/tests/tutorial-wrapping-c-library.test.yaml
+++ b/tests/tutorial-wrapping-c-library.test.yaml
@@ -595,10 +595,10 @@ sections:
           # macOS
           ./lm/bin/lm methods result/lib/calc_module_plugin.dylib
         expect_contains:
-          - "int add(int a, int b)"
-          - "int multiply(int a, int b)"
-          - "int factorial(int n)"
-          - "int fibonacci(int n)"
+          - "qlonglong add(qlonglong a, qlonglong b)"
+          - "qlonglong multiply(qlonglong a, qlonglong b)"
+          - "qlonglong factorial(qlonglong n)"
+          - "qlonglong fibonacci(qlonglong n)"
           - "QString libVersion()"
           - "Description: Adds two integers and returns the sum."
           - "Defined as n * (n-1) * ... * 1, with 0! = 1."
@@ -613,25 +613,25 @@ sections:
           Plugin Methods:
           ===============
 
-          int add(int a, int b)
-            Signature: add(int,int)
+          qlonglong add(qlonglong a, qlonglong b)
+            Signature: add(qlonglong,qlonglong)
             Invokable: yes
             Description: Adds two integers and returns the sum.
 
-          int multiply(int a, int b)
-            Signature: multiply(int,int)
+          qlonglong multiply(qlonglong a, qlonglong b)
+            Signature: multiply(qlonglong,qlonglong)
             Invokable: yes
             Description: Multiplies two integers and returns the product.
 
-          int factorial(int n)
-            Signature: factorial(int)
+          qlonglong factorial(qlonglong n)
+            Signature: factorial(qlonglong)
             Invokable: yes
             Description:
               Computes the factorial n! of a non-negative integer.
               Defined as n * (n-1) * ... * 1, with 0! = 1.
 
-          int fibonacci(int n)
-            Signature: fibonacci(int)
+          qlonglong fibonacci(qlonglong n)
+            Signature: fibonacci(qlonglong)
             Invokable: yes
             Description: Returns the nth Fibonacci number (0-indexed).
 
@@ -652,7 +652,7 @@ sections:
 
           Three things to notice:
 
-          - **Signatures are Qt-typed** (`int`, `QString`) even though you wrote `int64_t` / `std::string`. That's the generated glue: `lm` reports the wire types the synthesized Qt plugin exposes, so `int64_t add(int64_t, int64_t)` shows up as `add(int,int)`.
+          - **Signatures are Qt-typed** (`qlonglong`, `QString`) even though you wrote `int64_t` / `std::string`. That's the generated glue: `lm` reports the wire types the synthesized Qt plugin exposes, so `int64_t add(int64_t, int64_t)` shows up as `add(qlonglong,qlonglong)`. Note the width is **preserved** — `qlonglong` is Qt's 64-bit integer, not `int`. Each type in the contract maps to exactly one type per language, and integers are 64-bit throughout, so a value that fits your `int64_t` cannot be silently truncated on the way across.
           - **Each `Description` is your doc comment**, carried through the module's method introspection. Plain `//` comments (like the type-mapping note in the header) are deliberately ignored, so only intentional docs surface; an undocumented method simply omits it.
           - **Line breaks are preserved** — a single-line comment renders inline; a multi-line comment (`factorial`, `libVersion`, `libVersionNotify`) keeps its breaks. The same descriptions appear in `logoscore module-info` and Basecamp's Methods list.
 


### PR DESCRIPTION
CI has been red on every run since the dependencies moved underneath it. **The repo itself has not changed** — master's HEAD *is* the commit that last went green, on 2026-07-22. `logos-tutorial` has no `flake.lock`: the specs scaffold projects that resolve `github:logos-co/…` fresh at run time, so the same commit passes or fails depending on the day.

Both failures fixed here are the specs asserting behaviour that upstream deliberately changed.

## 1. Integer width: `int` → `qlonglong`

`lm methods` now reports `qlonglong add(qlonglong a, qlonglong b)` where the spec expected `int add(int a, int b)`. That is the LIDL type contract: one type per language, integers 64-bit throughout, no widening or narrowing.

The tutorial's explanation was not merely stale — **it documented the old bug as intended behaviour**, telling the reader their `int64_t` "shows up as `add(int,int)`". That silent 64→32 narrowing is exactly what the type contract removed. The bullet now says the width is preserved, and why that matters, which is the part a tutorial is for.

Only `tutorial-wrapping-c-library` asserts generator *output*, so only it moves. The `int` in `tutorial-cpp-ui-app` is C++ the reader writes themselves (`.rep` SLOTs and their own `override` declarations), where the reader picks the type — that spec passes and is deliberately left alone.

## 2. Basecamp navigation: section renamed, tab removed

`click("Modules")` failed with *"No clickable element found with text 'Modules'"*. On basecamp master the section label is now **"Module Inspector"** (`SettingsView.qml:53`), and the "Core Modules" tab is gone — it was split into its own view, which `ModuleInspectorView.qml:18` says in as many words: *"Formerly the 'Core Modules' tab of ModulesView."*

So the tab-click step is **deleted** rather than renamed, and the Interface screen is opened through `moduleInspectorView`, not `coreModulesView`.

Verified against `origin/master` of logos-basecamp, which is what CI builds: `openInterface(name)` still exists (`ModuleInspectorView.qml:46`), and the surrounding anchors `Settings`, `Sections`, `Dashboard` are all still present.

## Not fixed here — and it should stay red

The third failure, `persistenceDir` not containing `calc-data`, is **a real regression in `logos-logoscore-cli`**, not a stale expectation. [`daemon_state.cpp:264`](https://github.com/logos-co/logos-logoscore-cli/blob/master/src/daemon/daemon_state.cpp) applies `--persistence-path` only `if (cfg.dirs.data.empty())` — and `dirs.data` has a default, so **an explicitly passed CLI flag loses to a default, silently**. The comment says "dirs.data wins when both are set", which is true of two *config* values; it was not meant to mean "a default beats the command line".

The spec is correct as written and should keep failing until that is fixed separately. This PR therefore takes CI from **3 failures to 1**.

## Worth noting

Nothing here pins the drift itself. Because these specs resolve their inputs fresh at run time, the next upstream change lands the same way — a green commit going red without a commit. That is the underlying issue and it is out of scope for this fix.
