### PR TITLE
docs: stop documenting removed generator flags

### DIFF
--- a/logos-developer-guide.md
+++ b/logos-developer-guide.md
@@ -1033,8 +1033,9 @@ The generator is bundled with `logos-cpp-sdk`. It is automatically available:
 # Generate wrappers for a single module
 logos-cpp-generator /path/to/my_module_plugin.so --output-dir ./generated
 
-# Generate wrappers for all dependencies listed in metadata.json
-logos-cpp-generator --metadata metadata.json --module-dir /path/to/modules --output-dir ./generated
+# Generate a wrapper per dependency, each from that dependency's LIDL contract
+logos-cpp-generator --metadata metadata.json --general-only --output-dir ./generated \
+  --dep waku_module=/path/to/waku_module.lidl
 
 # Generate only module files (no umbrella headers)
 logos-cpp-generator /path/to/plugin.so --module-only --output-dir ./generated
@@ -1363,7 +1364,7 @@ logoscore stop                                # Stop daemon
 
 ```bash
 logos-cpp-generator <plugin-file> [--output-dir <dir>] [--module-only]
-logos-cpp-generator --metadata <metadata.json> --module-dir <dir> [--output-dir <dir>]
+logos-cpp-generator --metadata <metadata.json> --general-only --dep <name>=<name>.lidl [--output-dir <dir>]
 logos-cpp-generator --metadata <metadata.json> --general-only [--output-dir <dir>]
 ```
 

--- a/tutorial-dev-boost.md
+++ b/tutorial-dev-boost.md
@@ -276,8 +276,8 @@ logos_module(
     SOURCES
         src/calc_wrap_impl.h
         src/calc_wrap_impl.cpp
-        generated_code/calc_wrap_qt_glue.h
-        generated_code/calc_wrap_dispatch.cpp
+        generated_code/calc_wrap_cdylib_glue.h
+        generated_code/calc_wrap_cdylib_glue.cpp
         lib/libcalc.c                          # C source compiled directly
     INCLUDE_DIRS
         ${CMAKE_CURRENT_SOURCE_DIR}/generated_code


### PR DESCRIPTION
Two documentation corrections. Both name flags or artifacts the toolchain no longer produces, so following the guide as written fails.

**`docs: --module-dir was removed from logos-cpp-generator`** — the developer guide still showed

```
logos-cpp-generator --metadata metadata.json --module-dir /path/to/modules --output-dir ./generated
```

`--module-dir` walked a directory of BUILT plugins and introspected them; it is gone. The replacement generates a wrapper per dependency from that dependency's LIDL contract:

```
logos-cpp-generator --metadata metadata.json --general-only --output-dir ./generated \
  --dep waku_module=/path/to/waku_module.lidl
```

**`docs(dev-boost): name an artifact the toolchain can still produce`** — same class, in the dev-boost tutorial.

Docs only; no code, no build inputs.

Part of the B3/B4 line; Set 1, with no dependency on any other open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)