### PR TITLE
ci: use logos-co/setup-nix-cache-action for Nix setup and caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+    # ATTIC_TOKEN_PUBLIC only exists in the public-cache environment; master
+    # jobs must opt into it to publish to the public cache.
+    environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
@@ -42,17 +45,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-
-      - name: Setup Cachix
-        uses: cachix/cachix-action@v15
-        with:
-          name: logos-co
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-
       # The runner is the shared `doctest` CLI, invoked directly via its flake
+
+      - name: Setup Nix and Logos cache
+        uses: logos-co/setup-nix-cache-action@v1
+        with:
+          attic-token-ci: ${{ secrets.ATTIC_TOKEN_CI }}
+          attic-token-public: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
       # (github:logos-co/logos-doctest). The flake bundles Python + PyYAML
       # (+ rich), so no pip install step is needed.
       - name: Test - UI chain + Composing Modules + Dependency Interfaces (C Library tutorial pulled in via requires)


### PR DESCRIPTION
Converts this repo to `logos-co/setup-nix-cache-action` for Nix setup and caching, replacing the per-repo installer + `cachix/cachix-action` pair. The action installs Nix with the Logos Attic cache (`cache.nix.logos.co`) preconfigured and publishes what the job builds — master to the public cache, every other ref to `ci`.

Each converted job also gains

```yaml
environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
```

`ATTIC_TOKEN_PUBLIC` exists **only** inside that environment. Without the expression the secret resolves empty on master and publishing is silently skipped — the job still passes, so the omission would never surface as a failure.

### Two deliberate choices

**The action installs Nix on macOS too.** Several repos here used `DeterminateSystems/nix-installer-action` on macOS runners because `cachix/install-nix-action` collides with the runner's pre-existing `_nixbld` users (`eDSRecordAlreadyExists`). That no longer reproduces: `logos-delivery-module` is already converted the plain way and its `build-and-test (macos-latest)` leg passes. Keeping the workaround would have meant a second installer plus a duplicated substituter/key block for a failure that two green runs say does not happen. If it recurs it fails loudly at install, which is recoverable — unlike the silent-skip above.

**`continue-on-error` is not carried over.** The old cachix step had it, so a failed cache push could not fail a job whose tests passed. The action exposes no equivalent, and adding one would also swallow genuine setup failures now that the same step installs Nix rather than only publishing at the end.

Verified: every touched workflow parses (`yq`), no `cachix` / installer residue remains, and every job using the action carries the environment expression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)